### PR TITLE
Add HybridRenderer utility with examples and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/*.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # log-adianti
-Log para facilitar o debug no formato de dados utilizado pelo Adianti Framework
+
+Log para facilitar o debug no formato de dados utilizado pelo Adianti Framework.
+
+## HybridRenderer
+
+Este repositório inclui a classe [`Genesis\\LogHelpers\\HybridRenderer`](src/HybridRenderer.php), responsável por converter o conteúdo de logs do Adianti em HTML com duas visualizações complementares:
+
+- **Tabela plana** para coleções homogêneas (dados planos provenientes de `rawobj`).
+- **Árvore hierárquica** como fallback para estruturas complexas.
+
+Recursos extras:
+
+- Descriptografia opcional de campos com AES-256-CBC.
+- Normalização UTF-8 e escaping seguro de HTML.
+- Inserção opcional de `<meta charset="utf-8">` no início do HTML.
+
+## Exemplos
+
+Na pasta [`examples`](examples) há scripts PHP que podem ser executados diretamente:
+
+```bash
+php examples/basic_usage.php
+php examples/decrypt_usage.php
+```
+
+Cada script gera um arquivo HTML com o resultado da renderização na própria pasta `examples/`.
+
+## Documentação
+
+Para mais detalhes sobre o funcionamento interno, estrutura esperada dos dados e dicas de uso, consulte [`docs/hybrid-renderer.md`](docs/hybrid-renderer.md).

--- a/docs/hybrid-renderer.md
+++ b/docs/hybrid-renderer.md
@@ -1,0 +1,64 @@
+# HybridRenderer
+
+A classe `Genesis\LogHelpers\HybridRenderer` transforma o formato de log utilizado pelo Adianti Framework em HTML amigável, combinando a apresentação em tabela para dados planos e uma visualização hierárquica em árvore para estruturas mais complexas.
+
+## Principais recursos
+
+- **Descriptografia transparente**: suporta campos criptografados com AES-256-CBC, no formato `base64(IV||cipher)`.
+- **Decodificação de `rawobj`**: espera receber strings em base64 que representam um JSON plano. Após decodificar, o conteúdo é normalizado em UTF-8.
+- **Dois modos de visualização**:
+  - **Tabela plana** para coleções homogêneas compostas apenas por valores escalares.
+  - **Árvore** (fallback) para estruturas aninhadas, exibindo chaves e valores em uma lista hierárquica.
+- **HTML seguro**: todo o conteúdo é corretamente escapado para evitar injeção.
+- **Controle sobre `<meta charset>`**: opcionalmente insere `<meta charset="utf-8">` no início do HTML gerado.
+
+## Instalação
+
+Copie o arquivo [`src/HybridRenderer.php`](../src/HybridRenderer.php) para o seu projeto ou utilize este repositório como submódulo. Não há dependências externas além das extensões padrão do PHP para JSON, OpenSSL e (opcionalmente) `intl` para normalização Unicode.
+
+## Uso básico
+
+```php
+require 'src/HybridRenderer.php';
+
+use Genesis\LogHelpers\HybridRenderer;
+
+$renderer = new HybridRenderer(addMetaCharset: true);
+$html = $renderer->render($dadosDoLog);
+
+echo $html;
+```
+
+## Estrutura esperada
+
+- `record`: array associativo com os dados principais do registro.
+- `dataPage`: coleção de *details* retornados pelo Adianti. Cada `detail` deve conter uma chave `data`.
+- Outros campos são agrupados e exibidos na seção **Outros**.
+
+Sempre que existir a chave `rawobj` em um *detail*, o componente tentará decodificá-la seguindo as regras:
+
+1. Se a propriedade `$secret` foi informada, tenta descriptografar o valor de `rawobj`.
+2. Tenta decodificar o resultado como base64 contendo um JSON.
+3. Caso o JSON contenha apenas valores escalares (strings, números, booleanos ou `null`), o conjunto é exibido em tabela. Caso contrário, a visualização volta para a árvore.
+
+## Exemplos
+
+Veja a pasta [`examples`](../examples) para scripts executáveis que demonstram:
+
+- `basic_usage.php`: renderização simples com dados em claro.
+- `decrypt_usage.php`: renderização de dados criptografados, demonstrando como preparar o conteúdo antes de armazená-lo em `rawobj`.
+
+Execute os exemplos com:
+
+```bash
+php examples/basic_usage.php
+php examples/decrypt_usage.php
+```
+
+Os arquivos HTML gerados são gravados na própria pasta `examples/`.
+
+## Boas práticas
+
+- Utilize os métodos `clear()` e `getHtml()` quando precisar controlar o fluxo manualmente.
+- Prefira fornecer objetos simples (arrays ou `stdClass`); a classe cuidará da normalização para UTF-8.
+- Garanta que o JSON dentro de `rawobj` seja composto por valores escalares para usufruir da renderização tabular.

--- a/examples/basic_usage.php
+++ b/examples/basic_usage.php
@@ -1,0 +1,55 @@
+<?php
+require __DIR__ . '/../src/HybridRenderer.php';
+
+use Genesis\LogHelpers\HybridRenderer;
+
+$pedido = [
+    'record' => [
+        'id' => 1024,
+        'cliente' => 'João da Silva',
+        'status' => 'aberto',
+    ],
+    'dataPage' => [
+        'itens' => [
+            'composition' => ['var' => 'Itens do Pedido'],
+            'data' => [
+                ['rawobj' => base64_encode(json_encode([
+                    'produto' => 'Café em grãos',
+                    'quantidade' => 2,
+                    'preco_unitario' => 39.9,
+                ], JSON_UNESCAPED_UNICODE))],
+                ['rawobj' => base64_encode(json_encode([
+                    'produto' => 'Filtro de papel',
+                    'quantidade' => 1,
+                    'preco_unitario' => 8.5,
+                ], JSON_UNESCAPED_UNICODE))],
+            ],
+        ],
+        'enderecos' => [
+            'class' => 'EnderecoEntrega',
+            'data' => [
+                'principal' => [
+                    'logradouro' => 'Rua das Laranjeiras',
+                    'numero' => 321,
+                    'cidade' => 'Fortaleza',
+                ],
+                'alternativo' => [
+                    'logradouro' => 'Av. Atlântica',
+                    'numero' => 1000,
+                    'cidade' => 'Recife',
+                ],
+            ],
+        ],
+    ],
+    'meta' => [
+        'usuario' => 'ana.rocha',
+        'executado_em' => '2024-06-01T10:22:00Z',
+    ],
+];
+
+$renderer = new HybridRenderer(addMetaCharset: true);
+$html = $renderer->render($pedido);
+
+file_put_contents(__DIR__ . '/basic_usage.html', $html);
+
+echo "HTML gerado em examples/basic_usage.html\n";

--- a/examples/decrypt_usage.php
+++ b/examples/decrypt_usage.php
@@ -1,0 +1,58 @@
+<?php
+require __DIR__ . '/../src/HybridRenderer.php';
+
+use Genesis\LogHelpers\HybridRenderer;
+
+function encryptBase64Payload(string $base64Payload, string $secret): string
+{
+    $method = 'AES-256-CBC';
+    $ivLength = openssl_cipher_iv_length($method);
+    $iv = random_bytes($ivLength);
+    $key = hash('sha256', $secret, true);
+    $cipher = openssl_encrypt($base64Payload, $method, $key, OPENSSL_RAW_DATA, $iv);
+
+    if ($cipher === false) {
+        throw new RuntimeException('Falha ao criptografar payload.');
+    }
+
+    return base64_encode($iv . $cipher);
+}
+
+$secret = 'segredo-ultra-seguro';
+
+$log = [
+    'dataPage' => [
+        'Historico' => [
+            'class' => 'HistoricoPedidos',
+            'data' => [
+                [
+                    'rawobj' => encryptBase64Payload(
+                        base64_encode(json_encode([
+                            'evento' => 'aprovação',
+                            'responsavel' => 'Marina',
+                            'timestamp' => '2024-06-02T09:15:31-03:00',
+                        ], JSON_UNESCAPED_UNICODE)),
+                        $secret
+                    ),
+                ],
+                [
+                    'rawobj' => encryptBase64Payload(
+                        base64_encode(json_encode([
+                            'evento' => 'expedição',
+                            'responsavel' => 'Rogério',
+                            'timestamp' => '2024-06-02T14:02:10-03:00',
+                        ], JSON_UNESCAPED_UNICODE)),
+                        $secret
+                    ),
+                ],
+            ],
+        ],
+    ],
+];
+
+$renderer = new HybridRenderer(secret: $secret, addMetaCharset: true);
+
+$html = $renderer->render($log);
+file_put_contents(__DIR__ . '/decrypt_usage.html', $html);
+
+echo "HTML descriptografado gerado em examples/decrypt_usage.html\n";

--- a/src/HybridRenderer.php
+++ b/src/HybridRenderer.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Genesis\LogHelpers;
+/**
+ * Classe HybridRenderer
+ * ---------------------
+ * - Descriptografa campos (AES-256-CBC, base64(IV||cipher))
+ * - Decodifica base64→JSON de "rawobj"
+ * - Mostra TABELA PLANA para dados planos e fallback ÁRVORE para outros
+ * - Normaliza UTF-8 e escapa HTML corretamente
+ * - Não usa ob_start — mantém HTML em $this->html
+ */
+class HybridRenderer
+{
+    private ?string $secret;
+    private array $keysToDecrypt;
+    private bool $addMetaCharset;
+    private string $html = '';
+
+    public function __construct(?string $secret = null, array $keysToDecrypt = ['rawobj'], bool $addMetaCharset = false)
+    {
+        $this->secret = $secret;
+        $this->keysToDecrypt = $keysToDecrypt;
+        $this->addMetaCharset = $addMetaCharset;
+    }
+
+    /** Limpa o HTML armazenado */
+    public function clear(): void
+    {
+        $this->html = '';
+    }
+
+    /** Recupera o HTML gerado */
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    /** Método principal */
+    public function render($data): string
+    {
+        $this->clear();
+
+        $arr = is_object($data) ? json_decode(json_encode($data, JSON_UNESCAPED_UNICODE), true) : $data;
+        $arr = $this->normalizeUtf8Recursive($arr);
+
+        if ($this->addMetaCharset) {
+            $this->html .= "<meta charset=\"utf-8\">\n";
+        }
+
+        // Record
+        if (isset($arr['record']) && is_array($arr['record'])) {
+            $this->html .= "<h3>Record</h3>";
+            $this->html .= $this->renderTree($arr['record']);
+        }
+
+        // DataPage
+        if (isset($arr['dataPage']) && is_array($arr['dataPage'])) {
+            foreach ($arr['dataPage'] as $detailKey => $detail) {
+                $label = $detailKey;
+                if (isset($detail['composition']['var']))      $label = $detail['composition']['var'];
+                elseif (isset($detail['class']))               $label = $detail['class'];
+
+                $flat = $this->renderFlatDataTableFromDetail($detail, $label);
+                if ($flat !== null) {
+                    $this->html .= $flat;
+                } else {
+                    $this->html .= "<h3>" . $this->e($label) . "</h3>";
+                    $this->html .= $this->renderTree($detail);
+                }
+            }
+        }
+
+        // Outros
+        $others = $arr;
+        unset($others['record'], $others['dataPage']);
+        if (!empty($others)) {
+            $this->html .= "<h3>Outros</h3>";
+            $this->html .= $this->renderTree($others);
+        }
+
+        return $this->html;
+    }
+
+    /** Alias compatível */
+    public static function renderMultilevelTable($data, array $keysToDecrypt = ['rawobj'], ?string $secret = null, bool $addMetaCharset = false): string
+    {
+        $r = new self($secret, $keysToDecrypt, $addMetaCharset);
+        return $r->render($data);
+    }
+
+    /* ==============================================================
+       ========== MÉTODOS PRIVADOS: RENDERIZAÇÃO =====================
+       ============================================================== */
+
+    private function renderFlatDataTableFromDetail(array $detail, string $titulo = ''): ?string
+    {
+        if (!isset($detail['data']) || !is_array($detail['data'])) return null;
+
+        $rows = [];
+        foreach ($detail['data'] as $item) {
+            if (!is_array($item) || !array_key_exists('rawobj', $item)) return null;
+
+            $raw = $item['rawobj'];
+
+            if ($this->secret && in_array('rawobj', $this->keysToDecrypt, true) && is_string($raw) && $this->looksLikeBase64($raw)) {
+                $pt = $this->decryptValue($raw, $this->secret);
+                if ($pt !== null) $raw = $this->normalizeUtf8($pt);
+            }
+
+            $decoded = is_string($raw) ? $this->base64JsonToArray($raw) : null;
+            if ($decoded === null) return null;
+
+            foreach ($decoded as $vv) {
+                if (is_array($vv) || is_object($vv)) return null;
+            }
+
+            $rows[] = $this->normalizeUtf8Recursive($decoded);
+        }
+
+        if (!$rows) return null;
+
+        $cols = array_keys($rows[0]);
+        foreach ($rows as $r)
+            foreach ($r as $ck => $_)
+                if (!in_array($ck, $cols, true)) $cols[] = $ck;
+
+        $html = "<style>
+        .mono{font-family:ui-monospace,Menlo,Consolas,\"Liberation Mono\",monospace}
+        .dt-table{width:100%;border-collapse:collapse}
+        .dt-table th,.dt-table td{border:1px solid #ddd;padding:6px 8px;vertical-align:top}
+        .dt-table th{background:#f5f5f7}
+        .dt-scroll{overflow:auto;max-width:100%}
+        .section{margin:.8rem 0 1.2rem}
+        </style>";
+
+        $html .= "<div class='section'>";
+        if ($titulo) $html .= "<h3>" . $this->e($titulo) . " <span style='font-size:.75rem;background:#eef;color:#335;border-radius:.4rem;padding:.1rem .4rem;margin-left:.5rem'>tabela</span></h3>";
+        $html .= "<div class='dt-scroll'><table class='dt-table'><thead><tr>";
+        foreach ($cols as $c) $html .= "<th>" . $this->e($c) . "</th>";
+        $html .= "</tr></thead><tbody>";
+        foreach ($rows as $r) {
+            $html .= "<tr>";
+            foreach ($cols as $c) {
+                $val = array_key_exists($c, $r) ? (is_null($r[$c]) ? 'null' : (is_bool($r[$c]) ? ($r[$c] ? 'true' : 'false') : (string)$r[$c])) : '';
+                $html .= "<td class='mono'>" . $this->e($val) . "</td>";
+            }
+            $html .= "</tr>";
+        }
+        $html .= "</tbody></table></div></div>";
+        return $html;
+    }
+
+    private function renderTree($data): string
+    {
+        $data = $this->normalizeUtf8Recursive($data);
+
+        $build = function($node, $level = 0) use (&$build) {
+            $html = '';
+            if (is_array($node)) {
+                foreach ($node as $k => $v) {
+                    $pad = str_repeat('&nbsp;', $level * 4);
+                    if (is_array($v) || is_object($v)) {
+                        $html .= "<tr><td class='mono'>{$pad}" . $this->e((string)$k) . "</td><td class='mono'>[…]</td></tr>";
+                        $html .= $build(is_object($v) ? json_decode(json_encode($v, JSON_UNESCAPED_UNICODE), true) : $v, $level + 1);
+                    } else {
+                        $val = is_null($v) ? 'null' : (is_bool($v) ? ($v ? 'true' : 'false') : (string)$v);
+                        $html .= "<tr><td class='mono'>{$pad}" . $this->e((string)$k) . "</td><td class='mono'>" . $this->e($val) . "</td></tr>";
+                    }
+                }
+            } else {
+                $val = is_null($node) ? 'null' : (is_bool($node) ? ($node ? 'true' : 'false') : (string)$node);
+                $html .= "<tr><td class='mono'>(value)</td><td class='mono'>" . $this->e($val) . "</td></tr>";
+            }
+            return $html;
+        };
+
+        $html = "<style>
+        .mono{font-family:ui-monospace,Menlo,Consolas,\"Liberation Mono\",monospace}
+        .dt-table{width:100%;border-collapse:collapse}
+        .dt-table th,.dt-table td{border:1px solid #ddd;padding:6px 8px;vertical-align:top}
+        .dt-table th{background:#f5f5f7}
+        </style>";
+        $html .= "<div class='section'><table class='dt-table'><thead><tr><th style='width:40%'>Chave</th><th>Valor</th></tr></thead><tbody>";
+        $html .= $build($data, 0);
+        $html .= "</tbody></table></div>";
+        return $html;
+    }
+
+    /* ==============================================================
+       ========== MÉTODOS AUXILIARES (UTF-8, crypto, JSON) ===========
+       ============================================================== */
+    private function e($v): string
+    {
+        return htmlspecialchars((string)$v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    private function normalizeUtf8($s): string
+    {
+        if (!is_string($s)) return $s;
+        if (mb_detect_encoding($s, ['UTF-8','ISO-8859-1','Windows-1252','ASCII'], true) !== 'UTF-8') {
+            $converted = @iconv('ISO-8859-1', 'UTF-8//IGNORE', $s);
+            if ($converted !== false) return $converted;
+            return mb_convert_encoding($s, 'UTF-8', 'auto');
+        }
+        if (class_exists('\\Normalizer')) {
+            $n = \Normalizer::normalize($s, \Normalizer::FORM_C);
+            if ($n !== false) return $n;
+        }
+        return $s;
+    }
+
+    private function normalizeUtf8Recursive($val)
+    {
+        if (is_string($val)) return $this->normalizeUtf8($val);
+        if (is_array($val)) {
+            $out = [];
+            foreach ($val as $k => $v) {
+                $nk = is_string($k) ? $this->normalizeUtf8($k) : $k;
+                $out[$nk] = $this->normalizeUtf8Recursive($v);
+            }
+            return $out;
+        }
+        if (is_object($val)) {
+            $val = json_decode(json_encode($val, JSON_UNESCAPED_UNICODE), true);
+            return $this->normalizeUtf8Recursive($val);
+        }
+        return $val;
+    }
+
+    private function decryptValue(string $cipher_b64, string $secret): ?string
+    {
+        $bin = base64_decode($cipher_b64, true);
+        if ($bin === false) return null;
+        $method = 'AES-256-CBC';
+        $ivlen  = openssl_cipher_iv_length($method);
+        if (strlen($bin) <= $ivlen) return null;
+        $iv  = substr($bin, 0, $ivlen);
+        $ct  = substr($bin, $ivlen);
+        $key = hash('sha256', $secret, true);
+        $pt  = openssl_decrypt($ct, $method, $key, OPENSSL_RAW_DATA, $iv);
+        return $pt === false ? null : $pt;
+    }
+
+    private function looksLikeBase64(string $s): bool
+    {
+        $s = preg_replace('/\s+/', '', $s);
+        return $s !== '' && strlen($s) % 4 === 0 && base64_decode($s, true) !== false;
+    }
+
+    private function base64JsonToArray(string $s): ?array
+    {
+        if (!$this->looksLikeBase64($s)) return null;
+        $bin = base64_decode($s, true);
+        if ($bin === false) return null;
+        $jsonStr = $this->normalizeUtf8($bin);
+        $j = json_decode($jsonStr, true, 512, JSON_INVALID_UTF8_SUBSTITUTE);
+        return (json_last_error() === JSON_ERROR_NONE && is_array($j)) ? $this->normalizeUtf8Recursive($j) : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add the HybridRenderer class for rendering Adianti logs as HTML tables or trees
- document the renderer usage and expected structure
- provide runnable examples for plain and encrypted datasets
- declare the Genesis\\LogHelpers namespace and update examples and docs to reference it

## Testing
- php examples/basic_usage.php
- php examples/decrypt_usage.php

------
https://chatgpt.com/codex/tasks/task_e_68e161e6e6f8832b840ff6635e857ff2